### PR TITLE
feat: implement bidirectional skill installation and uninstallation f…

### DIFF
--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -6,9 +6,9 @@ use crate::types::{
 use crate::utils::download::copy_dir_recursive;
 use crate::utils::path::{normalize_path, resolve_canonical, sanitize_dir_name};
 use crate::utils::security::{is_absolute_ide_path, is_valid_ide_path};
+use std::fs;
 use std::fs::File;
 use std::io;
-use std::fs;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 use zip::write::SimpleFileOptions;
@@ -576,8 +576,10 @@ pub fn uninstall_skill(request: UninstallRequest) -> Result<String, String> {
         let base = PathBuf::from(project);
         allowed_roots.push(base.join(".codex/skills"));
         allowed_roots.push(base.join(".trae/skills"));
-        allowed_roots.push(base.join(".opencode/skill"));
+        allowed_roots.push(base.join(".opencode/skills"));
         allowed_roots.push(base.join(".skills-manager/skills"));
+        allowed_roots.push(base.join(".agents/skills"));
+        allowed_roots.push(base.join(".claude/skills"));
     }
 
     let target = PathBuf::from(&request.target_path);
@@ -843,4 +845,44 @@ pub fn scan_project_ide_dirs(request: ProjectScanRequest) -> Result<ProjectScanR
         project_dir: request.project_dir,
         detected_ide_dirs,
     })
+}
+
+#[tauri::command]
+pub fn scan_project_skills(
+    request: crate::types::ProjectSkillsRequest,
+) -> Result<Vec<LocalSkill>, String> {
+    let project_dir = PathBuf::from(&request.project_dir);
+    if !project_dir.exists() {
+        return Err("Project directory does not exist".to_string());
+    }
+
+    let dirs_to_scan: Vec<String> = if request.ide_dirs.is_empty() {
+        vec![
+            ".agents/skills".to_string(),
+            ".claude/skills".to_string(),
+            ".opencode/skills".to_string(),
+        ]
+    } else {
+        request
+            .ide_dirs
+            .iter()
+            .map(|item| item.relative_dir.clone())
+            .collect()
+    };
+
+    let mut unique_dirs = dirs_to_scan;
+    unique_dirs.sort();
+    unique_dirs.dedup();
+
+    let mut all_skills = Vec::new();
+
+    for relative_path in unique_dirs {
+        let skills_dir = project_dir.join(&relative_path);
+        let skills = collect_skills_from_dir(&skills_dir, "project", Some(&relative_path));
+        for skill in skills {
+            all_skills.push(skill);
+        }
+    }
+
+    Ok(all_skills)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,7 +6,7 @@ use tauri::Manager;
 use commands::market::{download_marketplace_skill, search_marketplaces, update_marketplace_skill};
 use commands::skills::{
     adopt_ide_skill, delete_local_skills, export_local_skills, import_local_skill,
-    link_local_skill, scan_overview, scan_project_ide_dirs, uninstall_skill,
+    link_local_skill, scan_overview, scan_project_ide_dirs, uninstall_skill, scan_project_skills,
 };
 
 pub use crate::types::{
@@ -14,7 +14,7 @@ pub use crate::types::{
     ImportRequest, InstallResult, LinkRequest, LinkTarget, LocalScanRequest, LocalSkill,
     MarketStatus, MarketStatusType, Overview, ProjectIdeDir, ProjectScanRequest,
     ProjectScanResult, RemoteSkill, RemoteSkillView, RemoteSkillsResponse,
-    RemoteSkillsViewResponse, UninstallRequest,
+    RemoteSkillsViewResponse, UninstallRequest, ProjectSkillsRequest,
 };
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -35,7 +35,8 @@ pub fn run() {
             delete_local_skills,
             export_local_skills,
             adopt_ide_skill,
-            scan_project_ide_dirs
+            scan_project_ide_dirs,
+            scan_project_skills
         ]);
 
     #[cfg(desktop)]

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -211,3 +211,11 @@ pub struct ProjectScanResult {
     pub project_dir: String,
     pub detected_ide_dirs: Vec<ProjectIdeDir>,
 }
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectSkillsRequest {
+    pub project_dir: String,
+    #[serde(default)]
+    pub ide_dirs: Vec<IdeDir>,
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,11 +18,12 @@ import LoadingOverlay from "./components/LoadingOverlay.vue";
 import Toast from "./components/Toast.vue";
 import ProjectAddModal from "./components/ProjectAddModal.vue";
 import ProjectConfigModal from "./components/ProjectConfigModal.vue";
+import UnmanagedSkillModal from "./components/UnmanagedSkillModal.vue";
 
 const { t } = useI18n();
 
 // Mark components as used for template
-void [ProjectsPanel, ProjectAddModal, ProjectConfigModal];
+void [ProjectsPanel, ProjectAddModal, ProjectConfigModal, UnmanagedSkillModal];
 
 const localeKey = "skillsManager.locale";
 const themeKey = "skillsManager.theme";
@@ -87,6 +88,8 @@ const {
   customIdeOptions,
   filteredIdeSkills,
   showInstallModal,
+  installTargetIde,
+  installTargetProjectIds,
   showUninstallModal,
   uninstallTargetName,
   uninstallMode,
@@ -150,6 +153,39 @@ function handleUpdateMarketSortMode(next: MarketSortMode) {
   marketSortMode.value = next;
 }
 
+const showUnmanagedModal = ref(false);
+const selectedUnmanagedSkill = ref<any>(null);
+
+function handleUnmanagedClick(skill: any) {
+  selectedUnmanagedSkill.value = skill;
+  showUnmanagedModal.value = true;
+}
+
+function handleUnmanagedSearch() {
+  if (!selectedUnmanagedSkill.value) return;
+  const rawName = selectedUnmanagedSkill.value.name;
+  query.value = rawName.replace(/[^a-zA-Z0-9\u4e00-\u9fa5]/g, ' ').replace(/\s+/g, ' ').trim();
+  
+  showUnmanagedModal.value = false;
+  activeTab.value = "market";
+  searchMarketplace();
+}
+
+function handleUnmanagedAdopt() {
+  if (!selectedUnmanagedSkill.value) return;
+  const skill = selectedUnmanagedSkill.value;
+  const ideSkill = {
+    id: skill.id,
+    name: skill.name,
+    path: skill.path,
+    ide: skill.ide || "",
+    source: skill.source || "project",
+    managed: false
+  };
+  adoptIdeSkill(ideSkill);
+  showUnmanagedModal.value = false;
+}
+
 async function handleAddProject() {
   showProjectAddModal.value = true;
 }
@@ -192,8 +228,8 @@ async function handleProjectConfigSave(projectId: string, ideTargets: string[]) 
 
 async function handleLinkSkills(projectId: string) {
   const project = projects.value.find((p) => p.id === projectId);
-  if (!project || project.ideTargets.length === 0) {
-    toast.error(t("errors.projectNoIdeTargets"));
+  if (!project) {
+    toast.error(t("errors.projectNoIdeTargets")); // The message might need an update later, but keeping as is for logic
     return;
   }
 
@@ -203,6 +239,17 @@ async function handleLinkSkills(projectId: string) {
   // Switch to local tab and let user select skills
   activeTab.value = "local";
   toast.info(t("messages.selectSkillsForProject", { name: project.name }));
+}
+
+const localPanelRef = ref<any>(null);
+
+function handleJumpToLocalSkill(skillName: string) {
+  activeTab.value = "local";
+  setTimeout(() => {
+    if (localPanelRef.value && typeof localPanelRef.value.setSearchQuery === 'function') {
+      localPanelRef.value.setSearchQuery(skillName);
+    }
+  }, 100);
 }
 </script>
 
@@ -284,6 +331,7 @@ async function handleLinkSkills(projectId: string) {
     <main class="content">
       <template v-if="activeTab === 'local'">
         <LocalPanel
+          ref="localPanelRef"
           :local-skills="localSkills"
           :local-loading="localLoading"
           :installing-id="installingId"
@@ -361,6 +409,8 @@ async function handleLinkSkills(projectId: string) {
           @select-project="handleSelectProject"
           @configure-project="handleConfigureProject"
           @link-skills="handleLinkSkills"
+          @jump-to-local-skill="handleJumpToLocalSkill"
+          @unmanaged-click="handleUnmanagedClick"
         />
       </template>
 
@@ -373,6 +423,8 @@ async function handleLinkSkills(projectId: string) {
       :visible="showInstallModal"
       :ide-options="ideOptions"
       :projects="projects"
+      :initial-ide-targets="installTargetIde"
+      :initial-project-ids="installTargetProjectIds"
       @confirm="confirmInstallToIde"
       @cancel="closeInstallModal"
     />
@@ -400,6 +452,14 @@ async function handleLinkSkills(projectId: string) {
     />
 
     <Toast />
+
+    <UnmanagedSkillModal
+      :visible="showUnmanagedModal"
+      :skill="selectedUnmanagedSkill"
+      @cancel="showUnmanagedModal = false"
+      @search="handleUnmanagedSearch"
+      @adopt="handleUnmanagedAdopt"
+    />
 
     <LoadingOverlay :visible="busy" :text="busyText" />
   </div>

--- a/src/components/InstallModal.vue
+++ b/src/components/InstallModal.vue
@@ -7,6 +7,8 @@ const props = defineProps<{
   visible: boolean;
   ideOptions: IdeOption[];
   projects: ProjectConfig[];
+  initialIdeTargets?: string[];
+  initialProjectIds?: string[];
 }>();
 
 const emit = defineEmits<{
@@ -18,6 +20,21 @@ const { t } = useI18n();
 
 const selectedIdeTargets = ref<string[]>([]);
 const selectedProjectIds = ref<string[]>([]);
+
+import { watch } from "vue";
+watch(
+  () => [props.visible, props.initialIdeTargets, props.initialProjectIds] as [boolean, string[] | undefined, string[] | undefined],
+  ([visible, ideTargets, projectIds]) => {
+    if (visible) {
+      selectedIdeTargets.value = ideTargets ? [...ideTargets] : [];
+      selectedProjectIds.value = projectIds ? [...projectIds] : [];
+    } else {
+      selectedIdeTargets.value = [];
+      selectedProjectIds.value = [];
+    }
+  },
+  { deep: true, immediate: true }
+);
 
 function toggleIdeTarget(ideId: string) {
   const index = selectedIdeTargets.value.indexOf(ideId);
@@ -38,21 +55,11 @@ function toggleProject(projectId: string) {
 }
 
 function confirmInstallToIde() {
-  if (selectedIdeTargets.value.length === 0) {
-    // Button should be disabled, but if clicked somehow, provide feedback
-    return;
-  }
   emit("confirm", "ide", [...selectedIdeTargets.value], props.projects);
-  selectedIdeTargets.value = [];
 }
 
 function confirmInstallToProject() {
-  if (selectedProjectIds.value.length === 0) {
-    // Button should be disabled, but if clicked somehow, provide feedback
-    return;
-  }
   emit("confirm", "project", [...selectedProjectIds.value], props.projects);
-  selectedProjectIds.value = [];
 }
 
 function close() {
@@ -135,10 +142,10 @@ function close() {
           </div>
 
           <div class="modal-footer">
-            <button class="primary" :disabled="selectedIdeTargets.length === 0" @click="confirmInstallToIde">
+            <button class="primary" @click="confirmInstallToIde">
               {{ t("installModal.installToIde") }}
             </button>
-            <button class="primary" :disabled="selectedProjectIds.length === 0 || projects.length === 0" @click="confirmInstallToProject">
+            <button class="primary" :disabled="projects.length === 0" @click="confirmInstallToProject">
               {{ t("installModal.installToProject") }}
             </button>
             <button class="ghost" @click="close">{{ t("installModal.cancel") }}</button>

--- a/src/components/LocalPanel.vue
+++ b/src/components/LocalPanel.vue
@@ -30,6 +30,12 @@ const emit = defineEmits<{
 const selectedIds = ref<string[]>([]);
 const searchQuery = ref("");
 
+defineExpose({
+  setSearchQuery: (query: string) => {
+    searchQuery.value = query;
+  }
+});
+
 const filteredLocalSkills = computed(() => {
   const keyword = searchQuery.value.trim().toLowerCase();
   if (!keyword) return props.localSkills;

--- a/src/components/ProjectsPanel.vue
+++ b/src/components/ProjectsPanel.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { ref, watch, onMounted } from "vue";
+import { invoke } from "@tauri-apps/api/core";
 import { revealItemInDir } from "@tauri-apps/plugin-opener";
 import type { ProjectConfig, LocalSkill, IdeOption } from "../composables/types";
 import { useI18n } from "vue-i18n";
@@ -19,6 +21,8 @@ const emit = defineEmits<{
   (e: "selectProject", projectId: string | null): void;
   (e: "configureProject", projectId: string): void;
   (e: "linkSkills", projectId: string): void;
+  (e: "jumpToLocalSkill", skillName: string): void;
+  (e: "unmanagedClick", skill: LocalSkill): void;
 }>();
 
 function handleAddProject() {
@@ -55,6 +59,76 @@ function buildIdeBadgeList(project: ProjectConfig) {
     active: true
   }));
 }
+
+function isManagedSkill(skill: LocalSkill) {
+  return props.localSkills.some((ls: LocalSkill) => ls.name === skill.name);
+}
+
+const projectSkillsMap = ref<Record<string, LocalSkill[]>>({});
+const collapsedGroups = ref<Record<string, boolean>>({});
+
+interface SkillGroup {
+  dir: string;
+  skills: LocalSkill[];
+}
+
+function getGroupedSkills(skills: LocalSkill[]): SkillGroup[] {
+  const map = new Map<string, LocalSkill[]>();
+  for (const skill of skills) {
+    const dir = skill.ide || 'Unknown Directory';
+    if (!map.has(dir)) {
+      map.set(dir, []);
+    }
+    map.get(dir)!.push(skill);
+  }
+  return Array.from(map.entries()).map(([dir, curSkills]) => ({ dir, skills: curSkills }));
+}
+
+function toggleGroup(projectId: string, dir: string) {
+  const key = `${projectId}:${dir}`;
+  collapsedGroups.value[key] = !collapsedGroups.value[key];
+}
+
+async function openSkillDir(projectPath: string, dir: string) {
+  try {
+    const separator = projectPath.includes('\\') ? '\\' : '/';
+    const cleanDir = dir.replace(/\//g, separator);
+    const suffix = projectPath.endsWith(separator) ? cleanDir : `${separator}${cleanDir}`;
+    const fullPath = `${projectPath}${suffix}`;
+    await revealItemInDir(fullPath);
+  } catch (err) {
+    console.error("Failed to open skill directory:", err);
+  }
+}
+
+async function loadProjectSkills() {
+  for (const project of props.projects) {
+    try {
+      const skills = await invoke<LocalSkill[]>("scan_project_skills", {
+        request: { 
+          projectDir: project.path,
+          ideDirs: props.ideOptions.map((ide: IdeOption) => ({
+            label: ide.label,
+            relativeDir: ide.projectDir || ide.globalDir
+          }))
+        }
+      });
+      projectSkillsMap.value[project.id] = skills;
+    } catch (e) {
+      console.error("Failed to load skills for project", project.path, e);
+      projectSkillsMap.value[project.id] = [];
+    }
+  }
+}
+
+watch(
+  () => [props.projects, props.localSkills],
+  () => {
+    loadProjectSkills();
+  },
+  { deep: true, immediate: true }
+);
+
 </script>
 
 <template>
@@ -102,7 +176,7 @@ function buildIdeBadgeList(project: ProjectConfig) {
             </button>
             <button
               class="primary small"
-              :disabled="localLoading || project.ideTargets.length === 0"
+              :disabled="localLoading"
               @click="handleLinkSkills(project.id)"
             >
               {{ t("projects.linkSkills") }}
@@ -132,6 +206,41 @@ function buildIdeBadgeList(project: ProjectConfig) {
           >
             {{ badge.label }}
           </span>
+        </div>
+        <div v-if="projectSkillsMap[project.id]?.length > 0" class="project-skills">
+          <div class="skills-title">{{ t("projects.installedSkills") || 'Installed Skills' }}:</div>
+          <div class="skill-groups">
+            <div 
+              v-for="group in getGroupedSkills(projectSkillsMap[project.id])" 
+              :key="group.dir" 
+              class="skill-group"
+            >
+              <div class="skill-group-header" @click="toggleGroup(project.id, group.dir)">
+                <div class="skill-group-title">
+                  <span class="fold-icon">
+                    <svg v-if="collapsedGroups[`${project.id}:${group.dir}`]" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
+                    <svg v-else xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
+                  </span>
+                  <span class="dir-name">{{ group.dir }}</span>
+                  <span class="skill-count">({{ group.skills.length }})</span>
+                </div>
+                <button class="icon-btn jump-btn" @click.stop="openSkillDir(project.path, group.dir)" title="Open Directory">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
+                </button>
+              </div>
+              <div class="skill-chips" v-show="!collapsedGroups[`${project.id}:${group.dir}`]">
+                <span
+                  v-for="skill in group.skills"
+                  :key="skill.id"
+                  class="skill-chip"
+                  :class="{ managed: isManagedSkill(skill) }"
+                  @click="isManagedSkill(skill) ? $emit('jumpToLocalSkill', skill.name) : $emit('unmanagedClick', skill)"
+                >
+                  {{ skill.name }}
+                </span>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -248,5 +357,135 @@ function buildIdeBadgeList(project: ProjectConfig) {
   background: var(--color-success-bg);
   color: var(--color-success-text);
   font-weight: 600;
+}
+
+.project-skills {
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--color-card-border);
+}
+
+.skills-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text);
+  margin-bottom: 8px;
+}
+
+.skill-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.skill-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.skill-group {
+  background: var(--color-card-bg);
+  border: 1px solid var(--color-card-border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.skill-group-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 10px;
+  background: rgba(0, 0, 0, 0.03);
+  cursor: pointer;
+  user-select: none;
+}
+[data-theme="dark"] .skill-group-header {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.skill-group-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--color-text);
+  flex: 1;
+}
+
+.fold-icon {
+  color: var(--color-muted);
+  width: 14px;
+  height: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dir-name {
+  font-family: inherit;
+  font-size: 13px;
+}
+
+.skill-count {
+  font-size: 12px;
+  color: var(--color-muted);
+}
+
+.jump-btn {
+  padding: 4px;
+  color: var(--color-muted);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.jump-btn:hover {
+  color: var(--color-primary);
+  background: rgba(0, 0, 0, 0.05);
+}
+[data-theme="dark"] .jump-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.skill-group .skill-chips {
+  margin-top: 0;
+  padding: 10px;
+  border-top: 1px solid var(--color-card-border);
+}
+
+.skill-chip {
+  padding: 4px 10px;
+  background: var(--color-chip-bg);
+  border: 1px solid var(--color-chip-border);
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--color-text);
+  transition: all 0.2s;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}
+
+.skill-chip:hover {
+  border-color: var(--color-primary-bg);
+  background: rgba(0, 113, 227, 0.05);
+}
+
+.skill-chip.managed {
+  border-color: var(--color-success-border);
+  color: var(--color-success-text);
+  background: var(--color-success-bg);
+  cursor: pointer;
+}
+
+.skill-chip.managed:hover {
+  filter: brightness(0.95);
 }
 </style>

--- a/src/components/UnmanagedSkillModal.vue
+++ b/src/components/UnmanagedSkillModal.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+import type { LocalSkill } from "../composables/types";
+
+defineProps<{
+  visible: boolean;
+  skill: LocalSkill | null;
+}>();
+
+defineEmits<{
+  (e: "adopt"): void;
+  (e: "search"): void;
+  (e: "cancel"): void;
+}>();
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <div v-if="visible && skill" class="modal-backdrop">
+    <div class="modal">
+      <div class="modal-title">
+        管理未纳管技能
+      </div>
+      <div class="hint">
+        该技能存在于项目本地但尚未受本应用统一管理，您希望执行什么操作？
+      </div>
+      <div class="card-link">{{ skill.name }}</div>
+      <div class="modal-actions" style="margin-top: 16px;">
+        <button class="ghost" @click="$emit('cancel')">{{ t("uninstallModal.cancel") || "取消" }}</button>
+        <div style="flex: 1;"></div>
+        <button class="primary" style="background: var(--color-primary-bg); color: var(--color-primary-text);" @click="$emit('search')">
+          去市场检索
+        </button>
+        <button class="primary" @click="$emit('adopt')">
+          纳入统一管理
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/UnmanagedSkillModal.vue
+++ b/src/components/UnmanagedSkillModal.vue
@@ -20,20 +20,20 @@ const { t } = useI18n();
   <div v-if="visible && skill" class="modal-backdrop">
     <div class="modal">
       <div class="modal-title">
-        管理未纳管技能
+        {{ t("unmanagedModal.title") }}
       </div>
       <div class="hint">
-        该技能存在于项目本地但尚未受本应用统一管理，您希望执行什么操作？
+        {{ t("unmanagedModal.hint") }}
       </div>
       <div class="card-link">{{ skill.name }}</div>
       <div class="modal-actions" style="margin-top: 16px;">
-        <button class="ghost" @click="$emit('cancel')">{{ t("uninstallModal.cancel") || "取消" }}</button>
+        <button class="ghost" @click="$emit('cancel')">{{ t("unmanagedModal.cancel") }}</button>
         <div style="flex: 1;"></div>
         <button class="primary" style="background: var(--color-primary-bg); color: var(--color-primary-text);" @click="$emit('search')">
-          去市场检索
+          {{ t("unmanagedModal.searchMarket") }}
         </button>
         <button class="primary" @click="$emit('adopt')">
-          纳入统一管理
+          {{ t("unmanagedModal.adopt") }}
         </button>
       </div>
     </div>

--- a/src/composables/constants.ts
+++ b/src/composables/constants.ts
@@ -4,18 +4,18 @@ import type { IdeOption, MarketStatus } from "./types";
  * Default IDE options available for skill installation
  */
 export const defaultIdeOptions: IdeOption[] = [
-  { id: "antigravity", label: "Antigravity", globalDir: ".gemini/antigravity/skills" },
-  { id: "claude", label: "Claude Code", globalDir: ".claude/skills" },
-  { id: "codebuddy", label: "CodeBuddy", globalDir: ".codebuddy/skills" },
-  { id: "codex", label: "Codex", globalDir: ".codex/skills" },
-  { id: "cursor", label: "Cursor", globalDir: ".cursor/skills" },
-  { id: "kiro", label: "Kiro", globalDir: ".kiro/skills" },
-  { id: "openclaw", label: "OpenClaw", globalDir: ".openclaw/skills" },
-  { id: "opencode", label: "OpenCode", globalDir: ".config/opencode/skills" },
-  { id: "qoder", label: "Qoder", globalDir: ".qoder/skills" },
-  { id: "trae", label: "Trae", globalDir: ".trae/skills" },
-  { id: "vscode", label: "VSCode", globalDir: ".github/skills" },
-  { id: "windsurf", label: "Windsurf", globalDir: ".windsurf/skills" }
+  { id: "antigravity", label: "Antigravity", globalDir: ".gemini/antigravity/skills",projectDir: ".agents/skills" },
+  { id: "claude", label: "Claude Code", globalDir: ".claude/skills",projectDir: ".claude/skills" },
+  { id: "codebuddy", label: "CodeBuddy", globalDir: ".codebuddy/skills",projectDir: ".codebuddy/skills" },
+  { id: "codex", label: "Codex", globalDir: ".agents/skills",projectDir: ".agents/skills" },
+  { id: "cursor", label: "Cursor", globalDir: ".cursor/skills",projectDir: ".cursor/skills" },
+  { id: "kiro", label: "Kiro", globalDir: ".kiro/skills",projectDir: ".kiro/skills" },
+  { id: "openclaw", label: "OpenClaw", globalDir: ".openclaw/skills",projectDir: ".agents/skills" },
+  { id: "opencode", label: "OpenCode", globalDir: ".config/opencode/skills",projectDir: ".opencode/skills" },
+  { id: "qoder", label: "Qoder", globalDir: ".qoder/skills",projectDir: ".qoder/skills" },
+  { id: "trae", label: "Trae", globalDir: ".trae/skills",projectDir: ".trae/skills" },
+  { id: "vscode", label: "VSCode", globalDir: ".copilot/skills",projectDir: ".github/skills" },
+  { id: "windsurf", label: "Windsurf", globalDir: ".codeium/.windsurf/skills",projectDir: ".windsurf/skills" }
 ];
 
 /**

--- a/src/composables/types.ts
+++ b/src/composables/types.ts
@@ -73,6 +73,7 @@ export type IdeOption = {
   id: string;
   label: string;
   globalDir: string;
+  projectDir: string;
 };
 
 /**

--- a/src/composables/useSkillsManager.ts
+++ b/src/composables/useSkillsManager.ts
@@ -59,6 +59,7 @@ export function useSkillsManager() {
   const showInstallModal = ref(false);
   const installTargetSkills = ref<LocalSkill[]>([]);
   const installTargetIde = ref<string[]>([]);
+  const installTargetProjectIds = ref<string[]>([]);
 
   const showUninstallModal = ref(false);
   const uninstallTargetPath = ref("");
@@ -111,6 +112,9 @@ export function useSkillsManager() {
     loadLastInstallTargets,
     saveLastInstallTargets
   } = useIdeConfig();
+
+  // Make sure we export installTargetProjectIds
+
 
   function addCustomIde() {
     const success = doAddCustomIde(t, (msg: string) => {
@@ -416,12 +420,43 @@ export function useSkillsManager() {
     return result;
   }
 
-  function openInstallModal(skill: LocalSkill | LocalSkill[]) {
+  async function openInstallModal(skill: LocalSkill | LocalSkill[]) {
     installTargetSkills.value = Array.isArray(skill) ? skill : [skill];
-    const lastTargets = loadLastInstallTargets();
-    const available = new Set(ideOptions.value.map((item) => item.label));
-    const nextTargets = lastTargets.filter((label) => available.has(label));
-    installTargetIde.value = nextTargets;
+    
+    if (installTargetSkills.value.length === 1) {
+      const singleSkill = installTargetSkills.value[0];
+      installTargetIde.value = ideOptions.value
+        .filter(ide => singleSkill.usedBy.includes(ide.label))
+        .map(ide => ide.label);
+
+      try {
+        const raw = localStorage.getItem("skillsManager.projects");
+        const projects: ProjectConfig[] = raw ? JSON.parse(raw) : [];
+        const installedProjectIds: string[] = [];
+        for (const p of projects) {
+          const pSkills = await invoke<LocalSkill[]>("scan_project_skills", {
+            request: { 
+              projectDir: p.path,
+              ideDirs: ideOptions.value.map(ide => ({
+                label: ide.label,
+                relativeDir: ide.projectDir || ide.globalDir
+              }))
+            }
+          });
+          if (pSkills.some(s => s.name === singleSkill.name)) {
+            installedProjectIds.push(p.id);
+          }
+        }
+        installTargetProjectIds.value = installedProjectIds;
+      } catch (err) {
+        console.error("Failed to load project skills for modal", err);
+        installTargetProjectIds.value = [];
+      }
+    } else {
+      installTargetIde.value = [];
+      installTargetProjectIds.value = [];
+    }
+
     showInstallModal.value = true;
   }
 
@@ -440,7 +475,7 @@ export function useSkillsManager() {
         return;
       }
       
-      if (installTargetSkills.value.length === 0 || targetIds.length === 0) {
+      if (installTargetSkills.value.length === 0) {
         toast.error(t("errors.selectAtLeastOne"));
         return;
       }
@@ -452,22 +487,91 @@ export function useSkillsManager() {
       try {
         let totalLinked = 0;
         let totalSkipped = 0;
+        let totalUninstalled = 0;
         
-        // Get selected projects
-        const selectedProjects = projects.filter(p => targetIds.includes(p.id));
-        
-        // Install to project directories
         for (const skill of installTargetSkills.value) {
-          for (const project of selectedProjects) {
-            for (const ideLabel of project.ideTargets) {
-              const result = await linkSkillToProjectInternal(skill, project, ideLabel, true, true);
-              totalLinked += result.linked.length;
-              totalSkipped += result.skipped.length;
+          const originalProjectIds = installTargetProjectIds.value;
+          const targetsToAdd = targetIds.filter(id => !originalProjectIds.includes(id));
+          const targetsToRemove = installTargetSkills.value.length === 1 
+            ? originalProjectIds.filter(id => !targetIds.includes(id))
+            : [];
+            
+          for (const projectId of targetsToAdd) {
+            const project = projects.find(p => p.id === projectId);
+            if (project) {
+              const linkTargets: LinkTarget[] = [];
+              const targetDirs = new Set<string>();
+              
+              if (project.ideTargets && project.ideTargets.length > 0) {
+                for (const ideLabel of project.ideTargets) {
+                  const targetIde = ideOptions.value.find(ide => ide.label === ideLabel);
+                  if (targetIde) {
+                    const dir = targetIde.projectDir || targetIde.globalDir;
+                    if (!targetDirs.has(dir)) {
+                      targetDirs.add(dir);
+                      linkTargets.push({ name: `Project (${dir})`, path: `${project.path}/${dir}` });
+                    }
+                  }
+                }
+              }
+              
+              if (linkTargets.length === 0) {
+                linkTargets.push({ name: `Project (.agents/skills)`, path: `${project.path}/.agents/skills` });
+              }
+
+              try {
+                const result = (await invoke("link_local_skill", {
+                  request: {
+                    skillPath: skill.path,
+                    skillName: skill.name,
+                    linkTargets
+                  }
+                })) as InstallResult;
+                totalLinked += result.linked.length;
+                totalSkipped += result.skipped.length;
+              } catch (err) {
+                console.error(`Failed to link skill to project ${project.name}:`, err);
+              }
+            }
+          }
+
+          for (const projectId of targetsToRemove) {
+            const project = projects.find(p => p.id === projectId);
+            if (project) {
+              try {
+                const pSkills = await invoke<LocalSkill[]>("scan_project_skills", {
+                  request: { 
+                    projectDir: project.path,
+                    ideDirs: ideOptions.value.map(ide => ({
+                      label: ide.label,
+                      relativeDir: ide.projectDir || ide.globalDir
+                    }))
+                  }
+                });
+                const installedSkills = pSkills.filter(s => s.name === skill.name);
+                for (const installedSkill of installedSkills) {
+                  await invoke("uninstall_skill", {
+                    request: {
+                      targetPath: installedSkill.path,
+                      projectDir: project.path,
+                      ideDirs: []
+                    }
+                  });
+                  totalUninstalled++;
+                }
+              } catch (err) {
+                console.error(`Failed to uninstall skill from project ${project.name}:`, err);
+              }
             }
           }
         }
         
-        toast.success(t("messages.handled", { linked: totalLinked, skipped: totalSkipped }));
+        if (totalLinked > 0 || totalUninstalled > 0) {
+          toast.success(t("messages.handledDetailed", { linked: totalLinked, skipped: totalSkipped, uninstalled: totalUninstalled }));
+        } else {
+          toast.info(t("messages.handledDetailed", { linked: totalLinked, skipped: totalSkipped, uninstalled: totalUninstalled }));
+        }
+        
         await scanLocalSkills();
         showInstallModal.value = false;
         installTargetSkills.value = [];
@@ -481,11 +585,12 @@ export function useSkillsManager() {
       return;
     }
     
-    // IDE installation (existing logic)
-    if (installTargetSkills.value.length === 0 || targetIds.length === 0) {
+    // IDE installation
+    if (installTargetSkills.value.length === 0) {
       toast.error(t("errors.selectAtLeastOne"));
       return;
     }
+    
     if (installingId.value) return;
     installingId.value = installTargetSkills.value.length === 1 ? installTargetSkills.value[0].id : "__batch__";
     busy.value = true;
@@ -494,17 +599,55 @@ export function useSkillsManager() {
     try {
       let totalLinked = 0;
       let totalSkipped = 0;
+      let totalUninstalled = 0;
       
       // Install to global IDE directories
       for (const skill of installTargetSkills.value) {
-        for (const label of targetIds) {
+        const originalTargets = ideOptions.value
+          .filter(ide => skill.usedBy.includes(ide.label))
+          .map(ide => ide.label);
+
+        const targetsToAdd = targetIds.filter(t => !originalTargets.includes(t));
+        
+        // Only perform removals if we are managing a single skill
+        const targetsToRemove = installTargetSkills.value.length === 1 
+          ? originalTargets.filter(t => !targetIds.includes(t))
+          : [];
+
+        // Add
+        for (const label of targetsToAdd) {
           const result = await linkSkillInternal(skill, label, true, true);
           totalLinked += result.linked.length;
           totalSkipped += result.skipped.length;
         }
+
+        // Remove
+        for (const label of targetsToRemove) {
+          const installedSkill = ideSkills.value.find(
+            s => s.ide === label && s.name === skill.name
+          );
+          if (installedSkill) {
+            await invoke("uninstall_skill", {
+              request: {
+                targetPath: installedSkill.path,
+                projectDir: null,
+                ideDirs: ideOptions.value.map(item => ({
+                  label: item.label,
+                  relativeDir: item.globalDir
+                }))
+              }
+            });
+            totalUninstalled++;
+          }
+        }
       }
       
-      toast.success(t("messages.handled", { linked: totalLinked, skipped: totalSkipped }));
+      if (totalLinked > 0 || totalUninstalled > 0) {
+        toast.success(t("messages.handledDetailed", { linked: totalLinked, skipped: totalSkipped, uninstalled: totalUninstalled }));
+      } else {
+        toast.info(t("messages.handledDetailed", { linked: totalLinked, skipped: totalSkipped, uninstalled: totalUninstalled }));
+      }
+      
       await scanLocalSkills();
       showInstallModal.value = false;
       installTargetSkills.value = [];
@@ -550,6 +693,7 @@ export function useSkillsManager() {
   function closeInstallModal() {
     showInstallModal.value = false;
     installTargetSkills.value = [];
+    installTargetProjectIds.value = [];
   }
 
   function openUninstallModal(targetPath: string) {
@@ -832,6 +976,7 @@ export function useSkillsManager() {
     customIdeDir,
     showInstallModal,
     installTargetIde,
+    installTargetProjectIds,
     showUninstallModal,
     uninstallTargetName,
     busy,

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -176,6 +176,7 @@ export default {
     exporting: "Exporting...",
     adopting: "Adding to central management...",
     handled: "Handled {linked} targets, skipped {skipped} targets.",
+    handledDetailed: "Installed {linked}, Uninstalled {uninstalled}, Skipped {skipped} targets.",
     imported: "Successfully imported {success} skills, failed {failed}.",
     exported: "Exported to {path}",
     selectSkillsForProject: "Select skills to install for project {name}"
@@ -248,6 +249,7 @@ export default {
     configureHint: "Select IDEs that this project needs. Skills will be linked to these IDE directories in the project.",
     cancel: "Cancel",
     save: "Save",
+    installedSkills: "Installed Skills",
     ideTargets: "IDE Targets: {count}",
     detected: "Detected: {count}",
     selectFolder: "Select Project Folder",

--- a/src/locales/en-US.ts
+++ b/src/locales/en-US.ts
@@ -158,6 +158,13 @@ export default {
     confirm: "Uninstall",
     deleteConfirm: "Delete"
   },
+  unmanagedModal: {
+    title: "Manage Unmanaged Skill",
+    hint: "This skill exists locally in the project but is not yet centrally managed by this app. What would you like to do?",
+    searchMarket: "Search in Market",
+    adopt: "Manage Centrally",
+    cancel: "Cancel"
+  },
   loading: {
     title: "Processing"
   },

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -157,6 +157,13 @@ export default {
     confirm: "确认卸载",
     deleteConfirm: "确认删除"
   },
+  unmanagedModal: {
+    title: "管理未纳管技能",
+    hint: "该技能存在于项目本地但尚未受本应用统一管理，您希望执行什么操作？",
+    searchMarket: "去市场检索",
+    adopt: "纳入统一管理",
+    cancel: "取消"
+  },
   loading: {
     title: "处理中"
   },

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -175,6 +175,7 @@ export default {
     exporting: "正在导出...",
     adopting: "正在纳入统一管理...",
     handled: "已处理 {linked} 个目标，跳过 {skipped} 个目标。",
+    handledDetailed: "成功安装 {linked} 个，卸载 {uninstalled} 个，跳过 {skipped} 个目标。",
     imported: "成功导入 {success} 个 Skill，失败 {failed} 个。",
     exported: "已导出到 {path}",
     selectSkillsForProject: "请为项目 {name} 选择要安装的 Skills"
@@ -247,6 +248,7 @@ export default {
     configureHint: "选择该项目需要使用的 IDE，安装 Skills 时会链接到这些 IDE 的项目目录。",
     cancel: "取消",
     save: "保存",
+    installedSkills: "已安装的扩展",
     ideTargets: "IDE 目标：{count} 个",
     detected: "已检测：{count} 个",
     selectFolder: "选择项目文件夹",


### PR DESCRIPTION
#18 

# Pull Request: 实现了项目和 IDE 的双向 Skill 安装与卸载功能

## 简介 (Introduction)
本 PR 主要实现了在项目 (Projects) 和 IDE 层面上进行双向的 Skill 安装与卸载功能。同时进一步完善了“项目内未纳管 (Unmanaged)” Skills 的发现与接管工作流，实现更流畅、直观的扩展 (Skill) 集中管理体验。

## 主要变更 (Key Changes)
- **双向安装与卸载逻辑 (Bidirectional Install/Uninstall):**
  - 重构了 `InstallModal.vue` 组件，现在允许在同一弹窗面板内直接勾选或取消勾选对应的项目/IDE，以触发安装或卸载操作。
  - Rust 后端 (`skills.rs`) 增加了对应的符号链接（Symlink）创建和移除的逻辑支持，并在 `types.rs` 中新增了处理结果细节的 DTO。

- **项目面板增强 (ProjectsPanel Enhancements):**
  - `ProjectsPanel.vue` 现支持扫描并渲染各项目专属目录下(`.agents/skills`, `.claude/skills` 等)的本地已应用扩展。
  - 新增 `UnmanagedSkillModal.vue` 组件：支持处理散落在项目目录中但未被统一管理的 Skills，一键将其纳管（Adopt）回主管理器。
  
- **核心逻辑重写 (Composables):**
  - 深度重构 `useSkillsManager.ts`，优化了针对目标 IDE 与项目管理的状态追踪逻辑 (`installTargetIde`, `installTargetProjectIds`) 及其交互方法。

- **界面与文案 (UI & Locales):**
  - 分别在 `en-US.ts` 和 `zh-CN.ts` 中增补了多语言词条（如“成功安装 {linked} 个，卸载 {uninstalled} 个，跳过 {skipped} 个目标。”及其他操作反馈文本）。
  - `LocalPanel.vue` 与主应用 `App.vue` 细节调整，适配最新组件与调用接口。